### PR TITLE
fix output text hover issue

### DIFF
--- a/src/content_components/translate.scss
+++ b/src/content_components/translate.scss
@@ -14,16 +14,13 @@
   }
   &:hover {
     cursor: pointer;
-    // background-color: white;
     background: transparent !important;
-    color: black !important;
     position: relative;
     span.close {
       display: inline-block;
       color: rgb(97, 96, 96);
       font-size: 18px !important;
       &:hover {
-        color: black;
         cursor: pointer;
       }
     }

--- a/src/content_script.global.scss
+++ b/src/content_script.global.scss
@@ -1,5 +1,5 @@
 .__translator_translate_container__ {
-  margin: 12px 0px !important;
+  margin: 11px 0px !important;
 }
 
 .__selected_words_marker_1__ {


### PR DESCRIPTION
There is a problem with the mouse over, the text changes colour from White to black, no readable.

link this issue: https://github.com/raymondmars/chatgpt-chrome-translate-plugin/issues/35