### PR TITLE
Preserve HTML tags during translation

### DIFF
--- a/src/hover_text_processor.tsx
+++ b/src/hover_text_processor.tsx
@@ -96,7 +96,7 @@ export default class HoverTextProcessor extends BaseProcessor {
   }
 
   private getElementText(element: Element): string {
-    return element.textContent?.trim() || '';
+    return element.innerHTML.trim();
   }
 
   private showPoptip(text: string) {

--- a/src/mouse_select_processor.tsx
+++ b/src/mouse_select_processor.tsx
@@ -32,8 +32,11 @@ export default class MouseSelectProcessor extends BaseProcessor {
     const selection = document.getSelection();
     const target = event.target as HTMLElement;
 
-    if (selection && selection?.toString().trim().length > 0 && !selection.isCollapsed) {
-      this.selectedText = selection?.toString().trim();
+    if (selection && !selection.isCollapsed) {
+      const range = selection.getRangeAt(0);
+      const container = document.createElement("div");
+      container.appendChild(range.cloneContents());
+      this.selectedText = container.innerHTML.trim();
       this.selectedElement = target;
     } else {
       this.selectedText = '';


### PR DESCRIPTION
This pull request updates the way text is extracted from the web page in order to preserve the original HTML formatting suck as italic, link, etc. during translation.

**Changes Made:**

- **MouseSelectProcessor:**  
  Instead of using `selection.toString()` to get the plain text, we now retrieve the HTML content by cloning the selection’s contents.  
  **Before:**
  ```ts
  if (selection && selection?.toString().trim().length > 0 && !selection.isCollapsed) {
    this.selectedText = selection.toString().trim();
    this.selectedElement = target;
  }
  ```  
  **After:**
  ```ts
  if (selection && !selection.isCollapsed) {
    const range = selection.getRangeAt(0);
    const container = document.createElement("div");
    container.appendChild(range.cloneContents());
    this.selectedText = container.innerHTML.trim();
    this.selectedElement = target;
  }
  ```

- **HoverTextProcessor:**  
  Updated the method to retrieve the element’s text so it now returns the inner HTML instead of plain text.  
  **Before:**
  ```ts
  private getElementText(element: Element): string {
    return element.textContent?.trim() || '';
  }
  ```  
  **After:**
  ```ts
  private getElementText(element: Element): string {
    return element.innerHTML.trim();
  }
  ```

**Impact:**  
These modifications ensure that the translated output maintains the original HTML structure (such as `<em>`, `<a>`, etc.), leading to improved fidelity and display of the content.
